### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/myapp/models.py
+++ b/myapp/models.py
@@ -18,6 +18,6 @@ class UserProfile(models.Model):
         db_table = "user_profile"
 
     def __unicode__(self):
-        return u'Profile of user: %s' % self.user.username
+        return u'Profile of user: {0!s}'.format(self.user.username)
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:siddharth-rawal:django-proof?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:siddharth-rawal:django-proof?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
